### PR TITLE
Fix memoizedCall to work with JIT compiler.

### DIFF
--- a/R/memoizedCall.R
+++ b/R/memoizedCall.R
@@ -44,7 +44,16 @@
 #*/#########################################################################
 setMethodS3("memoizedCall", "default", function(what, ..., envir=parent.frame(), force=FALSE, sources=NULL, dirs=NULL) {
   # 1. Generate cache file
-  key <- list(what=what, ...);
+
+  if (typeof(what)=="closure")
+    # do not compute the hash from the whole closure, because its internal
+    # state changes over time due to JIT activity (so the logically same function
+    # would get different hashes)
+    key <- list(body = body(what), formals = formals(what), attributes = attributes(what),
+                environment = environment(what), ...)
+  else
+    key <- list(what=what, ...);
+
   pathnameC <- generateCache(key=key, dirs=dirs);
 
   # 1. Look for memoized results


### PR DESCRIPTION
Currently memoizedCall does not work with the JIT compiler of R. The problem is that memoizedCall uses digest of a closure as key/identity for the closure when looking it up in the cache. Digest is computed from a serialized version of a closure, and hence contains also internal JIT state of that closure (whether it is compiled, should be compiled, its byte-code, etc). This internal state of a closure changes over time. Hence, memoizedCall would often not be able to re-use a cached result. This simple fix makes sure that memoizedCall does not use the internal JIT state for "what". It does not solve all the problems - e.g. it does not handle arguments which could also be closures. In general, it is not a good idea to use digest for similar purposes, because there could be more of varying internal state of objects in the future and by definition an internal state may change in unpredictable/unexpected situations.