### PR TITLE
Allow user to ignore errors in more cases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: R.cache
-Version: 0.12.1
+Version: 0.12.2
 Depends:
   R (>= 2.5.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: R.cache
-Version: 0.12.0
+Version: 0.12.1
 Depends:
   R (>= 2.5.0)
 Imports:

--- a/R/addMemoization.R
+++ b/R/addMemoization.R
@@ -39,7 +39,11 @@
 # @keyword "programming"
 # @keyword "IO"
 #*/#########################################################################
-setMethodS3("addMemoization", "default", function(fcn, envir=parent.frame(), ...) {
+setMethodS3("addMemoization", "default", function(fcn, envir=parent.frame(), ...,
+                                                  onError=c("warning", "print", "quiet", "error")) {
+
+  onError <- match.arg(onError);
+
   # Argument 'fcn':
   if (is.character(fcn)) {
     if (!exists(fcn, mode="function", envir=envir, inherits=TRUE)) {
@@ -58,7 +62,7 @@ setMethodS3("addMemoization", "default", function(fcn, envir=parent.frame(), ...
   }
 
   # Record the argument specific to memoizedCall().
-  memArgs <- list(...);
+  memArgs <- list(..., onError=onError);
 
   res <- function(..., envir=parent.frame()) {
     args <- list(fcn, ..., envir=envir);

--- a/R/memoizedCall.R
+++ b/R/memoizedCall.R
@@ -42,14 +42,18 @@
 # @keyword "programming"
 # @keyword "IO"
 #*/#########################################################################
-setMethodS3("memoizedCall", "default", function(what, ..., envir=parent.frame(), force=FALSE, sources=NULL, dirs=NULL) {
+setMethodS3("memoizedCall", "default", function(what, ..., envir=parent.frame(), force=FALSE, sources=NULL, dirs=NULL,
+                                                onError=c("warning", "print", "quiet", "error")) {
+
+  onError <- match.arg(onError);
+
   # 1. Generate cache file
   key <- list(what=what, ...);
   pathnameC <- generateCache(key=key, dirs=dirs);
 
   # 1. Look for memoized results
   if (!force) {
-    res <- loadCache(pathname=pathnameC, sources=sources);
+    res <- loadCache(pathname=pathnameC, sources=sources, onError=onError);
     if (!is.null(res)) return(res)
   }
 

--- a/R/memoizedCall.R
+++ b/R/memoizedCall.R
@@ -61,7 +61,7 @@ setMethodS3("memoizedCall", "default", function(what, ..., envir=parent.frame(),
   res <- do.call(what, args=list(...), quote=FALSE, envir=envir);
 
   # 3. Memoize results
-  saveCache(res, pathname=pathnameC, sources=sources);
+  saveCache(res, pathname=pathnameC, sources=sources, onError=onError);
 
   # 4. Return results
   res;

--- a/R/saveCache.R
+++ b/R/saveCache.R
@@ -54,7 +54,13 @@
 # @keyword "programming"
 # @keyword "IO"
 #*/#########################################################################
-setMethodS3("saveCache", "default", function(object, key=NULL, sources=NULL, suffix=".Rcache", comment=NULL, pathname=NULL, dirs=NULL, compress=getOption("R.cache::compress", FALSE), ...) {
+setMethodS3("saveCache", "default", function(object, key=NULL, sources=NULL, suffix=".Rcache", comment=NULL, pathname=NULL, dirs=NULL, compress=getOption("R.cache::compress", FALSE), ..., onError=c("warning", "print", "quiet", "error")) {
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  # Validate arguments
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  # Argument 'onError':
+  onError <- match.arg(onError);
+
   # Argument 'compress':
   if (!isTRUE(compress)) compress <- FALSE
 
@@ -71,12 +77,21 @@ setMethodS3("saveCache", "default", function(object, key=NULL, sources=NULL, suf
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   # Save to file connection
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+  tryCatch({
   if (compress) {
     pathname <- sprintf("%s.gz", pathname);
     fh <- gzfile(pathname, open="wb");
   } else {
     fh <- file(pathname, open="wb");
-  }
+  }}, error = function(ex) {
+    if (onError == "print") {
+      print(ex);
+    } else if (onError == "warning") {
+      warning(ex);
+    } else if (onError == "error") {
+      stop(ex);
+    }
+  })
   on.exit(close(fh));
 
   # Save 'identifier'


### PR DESCRIPTION
Add the onError argument to addMemoization, memoizedCall and saveCache.

This fixed #20 for me: when running code in parallel these errors can occur if one process has only written the cache header but not the data when another process tries to read it.

The tryCatch in saveCache prevents issues with file locks in parallel on windows: if two processes try to cache a result at the same time one will throw an error because it can't lock the cache file for writing.