### PR TITLE
Using R.cache.rootPath.ask or R_CACHE_ROOTPATH_ASK sys. env.

### DIFF
--- a/R/setupCacheRootPath.R
+++ b/R/setupCacheRootPath.R
@@ -56,7 +56,7 @@ setMethodS3("setupCacheRootPath", "default", function(defaultPath=NULL, ...) {
   defaultPath <- getDefaultCacheRootPath(defaultPath)
   if (isDirectory(defaultPath)) {
     rootPath <- defaultPath
-  } else if (interactive()) {
+  } else if (interactive() & !isFALSE(as.logical(getOption("R.cache.rootPath.ask", Sys.getenv("R_CACHE_ROOTPATH_ASK"))))) {
     # or we cn ask the user to confirm the default path...
     prompt <- "The R.cache package needs to create a directory that will hold cache files."
     if (identical(defaultPath, osDefaultPath)) {

--- a/tests/setupCacheRootPath.R
+++ b/tests/setupCacheRootPath.R
@@ -1,0 +1,12 @@
+
+options(R.cache.rootPath.ask=FALSE)
+Sys.setenv(R_CACHE_ROOTPATH_ASK=FALSE)
+R.cache:::setupCacheRootPath()
+
+options(R.cache.rootPath.ask=TRUE)
+Sys.setenv(R_CACHE_ROOTPATH_ASK=TRUE)
+R.cache:::setupCacheRootPath()
+
+
+## Cleanup
+R.cache::clearCache(recursive=TRUE)


### PR DESCRIPTION
With ver. 0.14.0, behavior of loaded library has change
In interactive mode (in RStudio) I will get a blocking message to create ~/.cache/R/R.cache/ path. 
This is blocking our Shiny apps. 
Maybe setting R option or system variable will not force to  prompt  the message. 

If R.cache.rootPath.ask option or R_CACHE_ROOTPATH_ASK system variable  will be false then prompt  will not appear 
R.cache.rootPath.ask  has priority over R_CACHE_ROOTPATH_ASK 
